### PR TITLE
Enhancements to `DateTime` and `TimeZone` objects.

### DIFF
--- a/src/Entities/Types/DateTime/Behaviours/Comparable.php
+++ b/src/Entities/Types/DateTime/Behaviours/Comparable.php
@@ -14,7 +14,6 @@ use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
  */
 trait Comparable
 {
-
     public function equals(object $object): bool
     {
         if (get_class($object) !== get_class($this)) {
@@ -108,9 +107,9 @@ trait Comparable
      *
      * @param DateTime|null $dt
      *
-     * @return DateTime
+     * @return static
      */
-    public function min(DateTime $dt = null): DateTime
+    public function min(DateTime $dt = null): static
     {
         $dt = $dt ?: static::now($this->timezone());
 
@@ -122,9 +121,9 @@ trait Comparable
      *
      * @see min()
      *
-     * @return DateTime
+     * @return static
      */
-    public function minimum(DateTime $dt = null): DateTime
+    public function minimum(DateTime $dt = null): static
     {
         return $this->min($dt);
     }
@@ -134,9 +133,9 @@ trait Comparable
      *
      * @param DateTime|null $dt
      *
-     * @return DateTime
+     * @return static
      */
-    public function max(DateTime $dt = null): DateTime
+    public function max(DateTime $dt = null): static
     {
         $dt = $dt ?: static::now($this->timezone());
 
@@ -148,9 +147,9 @@ trait Comparable
      *
      * @see max()
      *
-     * @return DateTime
+     * @return static
      */
-    public function maximum(DateTime $dt = null): DateTime
+    public function maximum(DateTime $dt = null): static
     {
         return $this->max($dt);
     }

--- a/src/Entities/Types/DateTime/Behaviours/Factory.php
+++ b/src/Entities/Types/DateTime/Behaviours/Factory.php
@@ -16,18 +16,17 @@ use Somnambulist\Components\Domain\Entities\Types\DateTime\TimeZone;
  */
 trait Factory
 {
-
-    public static function now($tz = null): DateTime
+    public static function now($tz = null): static
     {
         return static::parse('now', $tz instanceof TimeZone ? $tz : TimeZone::create($tz));
     }
 
-    public static function parse(string $time, TimeZone $tz): DateTime
+    public static function parse(string $time, TimeZone $tz): static
     {
         return new static($time, $tz->toNative());
     }
 
-    public static function parseUtc(string $time = 'now'): DateTime
+    public static function parseUtc(string $time = 'now'): static
     {
         return new static($time, new DateTimeZone('UTC'));
     }
@@ -47,9 +46,9 @@ trait Factory
      * @param null|int      $second
      * @param null|TimeZone $tz
      *
-     * @return DateTime
+     * @return static
      */
-    public static function create(int $year = null, int $month = null, int $day = null, int $hour = null, int $minute = null, int $second = null, TimeZone $tz = null): DateTime
+    public static function create(int $year = null, int $month = null, int $day = null, int $hour = null, int $minute = null, int $second = null, TimeZone $tz = null): static
     {
         [$nowYear, $nowMonth, $nowDay, $nowHour, $nowMin, $nowSec] = explode('-', date('Y-n-j-G-i-s', time()));
 
@@ -68,7 +67,7 @@ trait Factory
         );
     }
 
-    public static function createUtc(int $year = null, int $month = null, int $day = null, int $hour = null, int $minute = null, int $second = null): DateTime
+    public static function createUtc(int $year = null, int $month = null, int $day = null, int $hour = null, int $minute = null, int $second = null): static
     {
         return static::create($year, $month, $day, $hour, $minute, $second, TimeZone::utc());
     }
@@ -81,9 +80,9 @@ trait Factory
      * @param int|null      $day
      * @param TimeZone|null $tz
      *
-     * @return DateTime
+     * @return static
      */
-    public static function createFromDate(int $year, int $month, int $day, TimeZone $tz = null): DateTime
+    public static function createFromDate(int $year, int $month, int $day, TimeZone $tz = null): static
     {
         return static::create($year, $month, $day, null, null, null, $tz);
     }
@@ -96,9 +95,9 @@ trait Factory
      * @param int|null      $second
      * @param TimeZone|null $tz
      *
-     * @return DateTime
+     * @return static
      */
-    public static function createFromTime(int $hour, int $minute, int $second, TimeZone $tz = null): DateTime
+    public static function createFromTime(int $hour, int $minute, int $second, TimeZone $tz = null): static
     {
         return static::create(null, null, null, $hour, $minute, $second, $tz);
     }
@@ -108,7 +107,7 @@ trait Factory
      * @param string            $time
      * @param DateTimeZone|null $object
      *
-     * @return DateTime
+     * @return static
      */
     public static function createFromFormat(string $format, string $time, ?DateTimeZone $object = null)
     {

--- a/src/Entities/Types/DateTime/Behaviours/Modifiers.php
+++ b/src/Entities/Types/DateTime/Behaviours/Modifiers.php
@@ -2,8 +2,6 @@
 
 namespace Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours;
 
-use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
-
 /**
  * Trait Modifiers
  *
@@ -12,73 +10,72 @@ use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
  */
 trait Modifiers
 {
-
-    public function addDays(int $num): DateTime
+    public function addDays(int $num): static
     {
         return $this->modify(sprintf('%d day', $num));
     }
 
-    public function subDays(int $num): DateTime
+    public function subDays(int $num): static
     {
         return $this->addDays(-1 * $num);
     }
 
-    public function addWeeks(int $num): DateTime
+    public function addWeeks(int $num): static
     {
         return $this->modify(sprintf('%d week', $num));
     }
 
-    public function subWeeks(int $num): DateTime
+    public function subWeeks(int $num): static
     {
         return $this->addWeeks(-1 * $num);
     }
 
-    public function addMonths(int $num): DateTime
+    public function addMonths(int $num): static
     {
         return $this->modify(sprintf('%d month', $num));
     }
 
-    public function subMonths(int $num): DateTime
+    public function subMonths(int $num): static
     {
         return $this->addMonths(-1 * $num);
     }
 
-    public function addYears(int $num): DateTime
+    public function addYears(int $num): static
     {
         return $this->modify(sprintf('%d year', $num));
     }
 
-    public function subYears(int $num): DateTime
+    public function subYears(int $num): static
     {
         return $this->addYears(-1 * $num);
     }
 
-    public function addSeconds(int $num): DateTime
+    public function addSeconds(int $num): static
     {
         return $this->modify(sprintf('%d second', $num));
     }
 
-    public function subSeconds(int $num): DateTime
+    public function subSeconds(int $num): static
     {
         return $this->addSeconds(-1 * $num);
     }
 
-    public function addMinutes(int $num): DateTime
+    public function addMinutes(int $num): static
     {
         return $this->modify(sprintf('%d minute', $num));
     }
 
-    public function subMinutes(int $num): DateTime
+    public function subMinutes(int $num): static
     {
         return $this->addMinutes(-1 * $num);
     }
 
-    public function addHours(int $num): DateTime
+    public function addHours(int $num): static
     {
         return $this->modify(sprintf('%d hour', $num));
     }
 
-    public function subHours(int $num): DateTime
+    public function subHours(int $num): static
     {
         return $this->addHours(-1 * $num);
     }

--- a/src/Entities/Types/DateTime/Behaviours/Shifters.php
+++ b/src/Entities/Types/DateTime/Behaviours/Shifters.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours;
+
+/**
+ * Trait Shifters
+ *
+ * @package    Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours
+ * @subpackage Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Shifters
+ */
+trait Shifters
+{
+    public function startOf(string $unit, ...$args): static
+    {
+        $method = 'startOf' . ucfirst(strtolower($unit));
+
+        return $this->{$method}(...$args);
+    }
+
+    public function endOf(string $unit, ...$args): static
+    {
+        $method = 'endOf' . ucfirst(strtolower($unit));
+
+        return $this->{$method}(...$args);
+    }
+
+    public function startOfMinute(): static
+    {
+        return $this->setTime($this->hour(), $this->minute());
+    }
+
+    public function endOfMinute(): static
+    {
+        return $this->setTime($this->hour(), $this->minute(), 59);
+    }
+
+    public function startOfHour(): static
+    {
+        return $this->setTime($this->hour(), 0);
+    }
+
+    public function endOfHour(): static
+    {
+        return $this->setTime($this->hour(), 59, 59);
+    }
+
+    public function startOfDay(): static
+    {
+        return $this->setTime(0, 0);
+    }
+
+    public function endOfDay(): static
+    {
+        return $this->setTime(23, 59, 59);
+    }
+
+    public function startOfWeek(int $firstDow = -1): static
+    {
+        ($firstDow >= 0) or ($firstDow = $this->firstDayOfWeek());
+
+        return $this->subDays(($this->dayOfWeek() + 7 - $firstDow) % 7)->startOfDay();
+    }
+
+    public function endOfWeek(int $firstDow = -1): static
+    {
+        return $this->addDays(($this->lastDayOfWeek($firstDow) + 7 - $this->dayOfWeek()) % 7)->endOfDay();
+    }
+
+    public function startOfMonth(): static
+    {
+        return $this->setDate($this->year(), $this->month(), 1)->startOfDay();
+    }
+
+    public function endOfMonth(): static
+    {
+        return $this->setDate($this->year(), $this->month(), $this->daysInMonth())->endOfDay();
+    }
+
+    public function startOfQuarter(): static
+    {
+        $month = (int)(floor(($this->month() - 1) / 3) * 3) + 1;
+
+        return $this->setDate($this->year(), $month, 1)->startOfDay();
+    }
+
+    public function endOfQuarter(): static
+    {
+        $month = (int)(floor(($this->month() - 1) / 3) * 3) + 3;
+
+        return $this->setDate($this->year(), $month, 1)->endOfMonth();
+    }
+
+    public function startOfYear(): static
+    {
+        return $this->setDate($this->year(), 1, 1)->startOfDay();
+    }
+
+    public function endOfYear(): static
+    {
+        return $this->setDate($this->year(), 12, 31)->endOfDay();
+    }
+}

--- a/src/Entities/Types/DateTime/Behaviours/Stringable.php
+++ b/src/Entities/Types/DateTime/Behaviours/Stringable.php
@@ -3,7 +3,6 @@
 namespace Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours;
 
 use DateTime as PhpDateTime;
-use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
 
 /**
  * Trait Stringable
@@ -15,7 +14,6 @@ use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
  */
 trait Stringable
 {
-
     private string $defaultFormat = 'Y-m-d H:i:s';
 
     public function __toString(): string
@@ -28,7 +26,7 @@ trait Stringable
         return $this->format($this->defaultFormat);
     }
 
-    public function setDefaultFormat(string $format): DateTime
+    public function setDefaultFormat(string $format): static
     {
         $this->defaultFormat = $format;
 

--- a/src/Entities/Types/DateTime/DateTime.php
+++ b/src/Entities/Types/DateTime/DateTime.php
@@ -3,10 +3,12 @@
 namespace Somnambulist\Components\Domain\Entities\Types\DateTime;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use Somnambulist\Components\Domain\Entities\Contracts\ValueObject;
 use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Comparable;
 use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Factory;
 use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Modifiers;
+use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Shifters;
 use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Stringable;
 
 /**
@@ -17,10 +19,10 @@ use Somnambulist\Components\Domain\Entities\Types\DateTime\Behaviours\Stringable
  */
 class DateTime extends DateTimeImmutable implements ValueObject
 {
-
     use Comparable;
     use Factory;
     use Modifiers;
+    use Shifters;
     use Stringable;
 
     public function __set($name, $value)
@@ -28,9 +30,14 @@ class DateTime extends DateTimeImmutable implements ValueObject
         // prevent arbitrary properties
     }
 
-    public function clone(): DateTime
+    public function clone(): static
     {
         return clone $this;
+    }
+
+    public function toUtc(): static
+    {
+        return $this->setTimezone(new DateTimeZone('UTC'));
     }
 
     public function timezone(): TimeZone
@@ -68,6 +75,11 @@ class DateTime extends DateTimeImmutable implements ValueObject
         return (int)$this->format('s');
     }
 
+    public function millisecond(): int
+    {
+        return (int)$this->format('v');
+    }
+
     public function timestamp(): int
     {
         return (int)$this->format('U');
@@ -86,6 +98,19 @@ class DateTime extends DateTimeImmutable implements ValueObject
     public function dayOfWeek(): int
     {
         return (int)$this->format('w');
+    }
+
+    public function firstDayOfWeek(): int
+    {
+        // 0=Sun 1=Mon 2=Tue 3=Wed 4=Thu 5=Fri 6=Sat
+        return (new self('this week'))->dayOfWeek();
+    }
+
+    public function lastDayOfWeek(int $firstDow = -1): int
+    {
+        ($firstDow >= 0) or ($firstDow = $this->firstDayOfWeek());
+
+        return ($firstDow + 6) % 7;
     }
 
     public function dayOfYear(): int

--- a/src/Entities/Types/DateTime/TimeZone.php
+++ b/src/Entities/Types/DateTime/TimeZone.php
@@ -14,25 +14,24 @@ use Somnambulist\Components\Domain\Entities\AbstractValueObject;
  */
 class TimeZone extends AbstractValueObject
 {
-
     private string $value;
 
     public function __construct(string $tz)
     {
         Assert::that($tz, null, 'value')
             ->notEmpty()
-            ->satisfy(fn ($value) => false !== @timezone_open($value))
+            ->satisfy(static fn ($value) => false !== @timezone_open($value))
         ;
 
         $this->value = $tz;
     }
 
-    public static function create(string $tz = null): self
+    public static function create(string $tz = null): static
     {
         return new static($tz ?? date_default_timezone_get());
     }
 
-    public static function utc(): self
+    public static function utc(): static
     {
         return new static('UTC');
     }

--- a/tests/Entities/Types/DateTime/DateTime/ShiftersTest.php
+++ b/tests/Entities/Types/DateTime/DateTime/ShiftersTest.php
@@ -1,0 +1,289 @@
+<?php declare(strict_types=1);
+
+namespace Somnambulist\Components\Domain\Tests\Entities\Types\DateTime\DateTime;
+
+use DateTime as PhpDateTime;
+use PHPUnit\Framework\TestCase;
+use Somnambulist\Components\Domain\Entities\Types\DateTime\DateTime;
+
+/**
+ * Class ShiftersTest
+ *
+ * @package    Somnambulist\Components\Domain\Tests\Entities\Types\DateTime\DateTime
+ * @subpackage Somnambulist\Components\Domain\Tests\Entities\Types\DateTime\DateTime\ShiftersTest
+ *
+ * @group      entities
+ * @group      entities-types
+ * @group      entities-types-datetime
+ */
+class ShiftersTest extends TestCase
+{
+    protected const TEST_DATE = '2001-02-03 04:05:06.007+08:00'; // Saturday
+
+    public function testStartOfMinute()
+    {
+        $expected = new PhpDateTime('2001-02-03 04:05:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfMinute());
+        $this->assertEquals($expected, $testDate->startOf('minute'));
+    }
+
+    public function testEndOfMinute()
+    {
+        $expected = new PhpDateTime('2001-02-03 04:05:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfMinute());
+        $this->assertEquals($expected, $testDate->endOf('minute'));
+    }
+
+    public function testStartOfHour()
+    {
+        $expected = new PhpDateTime('2001-02-03 04:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfHour());
+        $this->assertEquals($expected, $testDate->startOf('hour'));
+    }
+
+    public function testEndOfHour()
+    {
+        $expected = new PhpDateTime('2001-02-03 04:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfHour());
+        $this->assertEquals($expected, $testDate->endOf('hour'));
+    }
+
+    public function testStartOfDay()
+    {
+        $expected = new PhpDateTime('2001-02-03 00:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfDay());
+        $this->assertEquals($expected, $testDate->startOf('day'));
+    }
+
+    public function testEndOfDay()
+    {
+        $expected = new PhpDateTime('2001-02-03 23:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfDay());
+        $this->assertEquals($expected, $testDate->endOf('day'));
+    }
+
+    public function testStartOfWeek()
+    {
+        $expected = new PhpDateTime('2001-01-29 00:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfWeek());
+        $this->assertEquals($expected, $testDate->startOf('week'));
+    }
+
+    /** @dataProvider startOfWeekTestData */
+    public function testStartOfWeekGivenFirstDayOfWeek(string $testDate, int $firstDow, string $expectedDate)
+    {
+        $expected = new PhpDateTime("{$expectedDate} 00:00:00+08:00");
+        $testDate = new DateTime($testDate);
+
+        $this->assertEquals($expected, $testDate->startOfWeek($firstDow));
+        $this->assertEquals($expected, $testDate->startOf('week', $firstDow));
+    }
+
+    public function startOfWeekTestData(): array
+    {
+        // [ testDate, firstDow, expectedDate ]
+        return [
+            [self::TEST_DATE, 0, '2001-01-28'],
+            [self::TEST_DATE, 1, '2001-01-29'],
+            [self::TEST_DATE, 2, '2001-01-30'],
+            [self::TEST_DATE, 3, '2001-01-31'],
+            [self::TEST_DATE, 4, '2001-02-01'],
+            [self::TEST_DATE, 5, '2001-02-02'],
+            [self::TEST_DATE, 6, '2001-02-03'],
+            // out-of-range should still work
+            [self::TEST_DATE, 7, '2001-01-28'],
+            [self::TEST_DATE, 8, '2001-01-29'],
+            // test start-of-year
+            ['2003-01-04 +0800', 0, '2002-12-29'],
+            ['2003-01-04 +0800', 1, '2002-12-30'],
+            ['2003-01-04 +0800', 2, '2002-12-31'],
+            ['2003-01-04 +0800', 3, '2003-01-01'],
+            ['2003-01-04 +0800', 4, '2003-01-02'],
+            ['2003-01-04 +0800', 5, '2003-01-03'],
+            ['2003-01-04 +0800', 6, '2003-01-04'],
+            // out-of-range should still work
+            ['2003-01-04 +0800', 7, '2002-12-29'],
+            ['2003-01-04 +0800', 8, '2002-12-30'],
+        ];
+    }
+
+    public function testEndOfWeek()
+    {
+        $expected = new PhpDateTime('2001-02-04 23:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfWeek());
+        $this->assertEquals($expected, $testDate->endOf('week'));
+    }
+
+    /** @dataProvider endOfWeekTestData */
+    public function testEndOfWeekGivenFirstDayOfWeek(string $testDate, int $firstDow, string $expectedDate)
+    {
+        $expected = new PhpDateTime("{$expectedDate} 23:59:59+08:00");
+        $testDate = new DateTime($testDate);
+
+        $this->assertEquals($expected, $testDate->endOfWeek($firstDow));
+        $this->assertEquals($expected, $testDate->endOf('week', $firstDow));
+    }
+
+    public function endOfWeekTestData(): array
+    {
+        // [ testDate, firstDow, expectedDate ]
+        return [
+            [self::TEST_DATE, 0, '2001-02-03'],
+            [self::TEST_DATE, 1, '2001-02-04'],
+            [self::TEST_DATE, 2, '2001-02-05'],
+            [self::TEST_DATE, 3, '2001-02-06'],
+            [self::TEST_DATE, 4, '2001-02-07'],
+            [self::TEST_DATE, 5, '2001-02-08'],
+            [self::TEST_DATE, 6, '2001-02-09'],
+            // out-of-range should still work
+            [self::TEST_DATE, 7, '2001-02-03'],
+            [self::TEST_DATE, 8, '2001-02-04'],
+            // test end-of-year
+            ['2002-12-28 +0800', 0, '2002-12-28'],
+            ['2002-12-28 +0800', 1, '2002-12-29'],
+            ['2002-12-28 +0800', 2, '2002-12-30'],
+            ['2002-12-28 +0800', 3, '2002-12-31'],
+            ['2002-12-28 +0800', 4, '2003-01-01'],
+            ['2002-12-28 +0800', 5, '2003-01-02'],
+            ['2002-12-28 +0800', 6, '2003-01-03'],
+            // out-of-range should still work
+            ['2002-12-28 +0800', 7, '2002-12-28'],
+            ['2002-12-28 +0800', 8, '2002-12-29'],
+        ];
+    }
+
+    public function testStartOfMonth()
+    {
+        $expected = new PhpDateTime('2001-02-01 00:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfMonth());
+        $this->assertEquals($expected, $testDate->startOf('month'));
+    }
+
+    public function testEndOfMonth()
+    {
+        $expected = new PhpDateTime('2001-02-28 23:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfMonth());
+        $this->assertEquals($expected, $testDate->endOf('month'));
+    }
+
+    public function testEndOfMonthLeapYear()
+    {
+        $expected = new PhpDateTime('2000-02-29 23:59:59+08:00');
+        $testDate = new DateTime('2000-02-15 +08:00');
+
+        $this->assertEquals($expected, $testDate->endOfMonth());
+        $this->assertEquals($expected, $testDate->endOf('month'));
+    }
+
+    public function testStartOfQuarter()
+    {
+        $expected = new PhpDateTime('2001-01-01 00:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfQuarter());
+        $this->assertEquals($expected, $testDate->startOf('quarter'));
+
+        $expected = new PhpDateTime('2001-04-01 00:00:00+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->startOfQuarter());
+        $this->assertEquals($expected, $testDate->startOf('quarter'));
+
+        $expected = new PhpDateTime('2001-07-01 00:00:00+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->startOfQuarter());
+        $this->assertEquals($expected, $testDate->startOf('quarter'));
+
+        $expected = new PhpDateTime('2001-10-01 00:00:00+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->startOfQuarter());
+        $this->assertEquals($expected, $testDate->startOf('quarter'));
+    }
+
+    public function testEndOfQuarter()
+    {
+        $expected = new PhpDateTime('2001-03-31 23:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfQuarter());
+        $this->assertEquals($expected, $testDate->endOf('quarter'));
+
+        $expected = new PhpDateTime('2001-06-30 23:59:59+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->endOfQuarter());
+        $this->assertEquals($expected, $testDate->endOf('quarter'));
+
+        $expected = new PhpDateTime('2001-09-30 23:59:59+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->endOfQuarter());
+        $this->assertEquals($expected, $testDate->endOf('quarter'));
+
+        $expected = new PhpDateTime('2001-12-31 23:59:59+08:00');
+        $testDate = $testDate->addMonths(3);
+
+        $this->assertEquals($expected, $testDate->endOfQuarter());
+        $this->assertEquals($expected, $testDate->endOf('quarter'));
+    }
+
+    public function testStartOfYear()
+    {
+        $expected = new PhpDateTime('2001-01-01 00:00:00+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->startOfYear());
+        $this->assertEquals($expected, $testDate->startOf('year'));
+    }
+
+    public function testEndOfYear()
+    {
+        $expected = new PhpDateTime('2001-12-31 23:59:59+08:00');
+        $testDate = new DateTime(self::TEST_DATE);
+
+        $this->assertEquals($expected, $testDate->endOfYear());
+        $this->assertEquals($expected, $testDate->endOf('year'));
+    }
+
+    public function testStartOfMethodIsCaseInsensitive()
+    {
+        $testDate = new DateTime();
+        $expected = $testDate->startOfYear();
+
+        $this->assertEquals($expected, $testDate->startOf('YEAR'));
+        $this->assertEquals($expected, $testDate->startOf('Year'));
+        $this->assertEquals($expected, $testDate->startOf('YeAr'));
+    }
+
+    public function testEndOfMethodIsCaseInsensitive()
+    {
+        $testDate = new DateTime();
+        $expected = $testDate->endOfYear();
+
+        $this->assertEquals($expected, $testDate->endOf('YEAR'));
+        $this->assertEquals($expected, $testDate->endOf('Year'));
+        $this->assertEquals($expected, $testDate->endOf('YeAr'));
+    }
+}

--- a/tests/Entities/Types/DateTime/DateTimeTest.php
+++ b/tests/Entities/Types/DateTime/DateTimeTest.php
@@ -19,7 +19,6 @@ use Somnambulist\Components\Domain\Entities\Types\Measure\AreaUnit;
  */
 class DateTimeTest extends TestCase
 {
-
     use Helpers;
 
     public function testCanCastToString()
@@ -53,5 +52,38 @@ class DateTimeTest extends TestCase
         $vo->foo = 'bar';
 
         $this->assertObjectNotHasAttribute('foo', $vo);
+    }
+
+    public function testToUtc()
+    {
+        $dt = new DateTime('2001-02-03 04:05:06.007+08:00');
+
+        $this->assertEquals(new \DateTime('2001-02-02 20:05:06.007+00:00'), $dt->toUtc());
+    }
+
+    public function testFirstDayOfWeek()
+    {
+        $this->assertEquals(1, (new DateTime())->firstDayOfWeek());
+    }
+
+    public function testLastDayOfWeek()
+    {
+        $this->assertEquals(0, (new DateTime())->lastDayOfWeek());
+    }
+
+    /** @dataProvider lastDayOfWeekTestData */
+    public function testLastDayOfWeekGivenFirstDayOfWeek(int $firstDow, int $lastDow)
+    {
+        $this->assertEquals($lastDow, (new DateTime())->lastDayOfWeek($firstDow));
+    }
+
+    public function lastDayOfWeekTestData(): array
+    {
+        // [ firstDow, lastDow ]
+        return [
+            [0, 6], [1, 0], [2, 1], [3, 2], [4, 3], [5, 4], [6, 5],
+            // out-of-range should still work
+            [7, 6], [8, 0],
+        ];
     }
 }


### PR DESCRIPTION
- Method return type hints are now `static` instead of class name.
- Added `DateTime::startOf*()` and `DateTime::endOf*()` methods.
- Added `DateTime::toUtc()` method.